### PR TITLE
IOS 9 fix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import swal from 'sweetalert2';
 import 'sweetalert2/dist/sweetalert2.min.css';
 
 
-const VueSweetalert2 = function() {};
+var VueSweetalert2 = function() {};
 
 VueSweetalert2.install = function(Vue) {
     // 1. добавление глобального метода или свойства


### PR DESCRIPTION
The project was breaking in Safari on ios 9 and below. Safari's console message was as follows: "SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.".

The current version of Vuejs is written in strict mode and for some reason this only breaks on ios 9 and later. I changed the const into a var and everything works. I tested across Safari, Chrome, Firefox, Opera, and Edge with no issues. Also tested across an array of mobile devices and found no issues. 