### PR TITLE
Modify the import for sweetalert to not import the stylesheet

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 
 import {SweetAlertOptions} from 'sweetalert2';
-import Swal from 'sweetalert2';
+import Swal from 'sweetalert2/dist/sweetalert2.js';
 
 type VueSwalInstance = typeof Swal.fire;
 


### PR DESCRIPTION
As per the [Sweetalert2 documentation](https://sweetalert2.github.io/#usage), the file 'sweetalert2/dist/sweetalert2.js' must be imported instead of the 'sweetalert2' module to import the stylesheet separatly.  
Importing the 'sweetalert2' module completely will also import stylesheet and it will not be possible to use custom style.  