### PR TITLE
nuxt: inject to context

### DIFF
--- a/nuxt/plugin.js
+++ b/nuxt/plugin.js
@@ -2,3 +2,6 @@ import Vue from 'vue';
 import VueSweetalert2 from 'vue-sweetalert2';
 
 Vue.use(VueSweetalert2, <%= JSON.stringify(options, null, 2) %>);
+export default ({}, inject) => {
+  inject('swal', Vue.swal)
+}


### PR DESCRIPTION
Adding inject for nuxt plugin. So people can use swal in middlewares and other plugins.