### PR TITLE
Updated readme with more info about using vue-sweetalert2 with vuex without breaking state machine  pattern.

### DIFF
--- a/packages/vue-sweetalert2/README.md
+++ b/packages/vue-sweetalert2/README.md
@@ -145,6 +145,13 @@ $swal2-background: #990000;
 @import '~sweetalert2/src/sweetalert2';
 ```
 
+## Vuex
+
+Demo of using this library with the **Vuex Actions** can be found [HERE.](https://github.com/Uraharadono/CallbackFromVuexAction/blob/master/README.md "HERE.") 
+
+This demo shows a simple pattern that enables you to call `vue-sweetalert2` from Vuex Actions without breaking state pattern. 
+
+
 ## Nuxt.js
 
 Install dependencies:


### PR DESCRIPTION
I wrote recently a post on my **GitHub** along with **sample demo** that is using **vue-sweetalert2** to show messages from **Ajax calls** that are done in **Vuex Action**. 

I think a lot of people would benefit from this, as I spent a lot of time on figuring this out when setting up the project. 