### PR TITLE
fix Module not found: Error: Default condition should be last one on v5.0.9

### DIFF
--- a/packages/vue-sweetalert2/package.json
+++ b/packages/vue-sweetalert2/package.json
@@ -8,10 +8,10 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "default": "./dist/vue-sweetalert.js",
       "import": "./dist/vue-sweetalert.mjs",
       "require": "./dist/vue-sweetalert.umd.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/vue-sweetalert.js"
     }
   },
   "files": [


### PR DESCRIPTION
Hi,

This PR fix the issue #158 on v5.0.9.

Fix this error message : Module not found: Error: Default condition should be last one

BR,
Nick